### PR TITLE
feat: project search

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ current project houses an empty repository.
 
 ### Creating new rules
 
-Rules must implement the `Ruler` interface and they must have at least the
+Rules must implement the [Ruler][file.rules.ruler] interface and they must have at least the
 following fields on their struct:
 
 ```go
@@ -76,7 +76,8 @@ type Ruler interface {
 	GetSlug() string
 	GetLevel() string
 }
-
+```
+```go
 type MyAwesomeRule struct {
 	Description string `json:"description"`
 	ID          string `json:"ruleId"`
@@ -118,7 +119,6 @@ your new rule being returned by running a GET to `/api/v1/rules`:
     "level": "error",
     "name": "My Awesome Rule"
   }
-  (...)
 ]
 ```
 
@@ -128,5 +128,6 @@ Fork the repository and send your pull-requests.
 
 
 [personal_access_tokens]: https://docs.gitlab.com/ce/user/profile/personal_access_tokens.html
+[file.rules.ruler]: ./rules/ruler.go
 [file.rules.levels]: ./rules/levels.go
 [file.rules.my_registry]: ./rules/my_registry.go

--- a/api/projects.go
+++ b/api/projects.go
@@ -44,11 +44,11 @@ func (s *server) projects(c echo.Context) error {
 	optProjects.SetSkip(int64((page - 1) * perPage))
 	optProjects.SetLimit(int64(perPage))
 
-	project := rules.Project{}
+	project := &rules.Project{}
 	searchStr := c.QueryParam("q")
 	searchQuery := s.db.BuildSearchQueryFromString(searchStr, project)
 
-	data, err := s.db.GetAll(&project, searchQuery, optProjects)
+	data, err := s.db.GetAll(project, searchQuery, optProjects)
 	if err != nil {
 		return err
 	}

--- a/api/projects.go
+++ b/api/projects.go
@@ -46,7 +46,7 @@ func (s *server) projects(c echo.Context) error {
 
 	project := &rules.Project{}
 	searchStr := c.QueryParam("q")
-	searchQuery := s.db.BuildSearchQueryFromString(searchStr, project)
+	searchQuery := s.db.BuildSearchQueryFromString(project, searchStr)
 
 	data, err := s.db.GetAll(project, searchQuery, optProjects)
 	if err != nil {

--- a/api/projects.go
+++ b/api/projects.go
@@ -21,6 +21,7 @@ import (
 // @ID get-projects
 // @Accept json
 // @Produce json
+// @Param q query string false "fuzzy search projects"
 // @Success 200 {array} rules.Project
 // @Router /projects [get]
 func (s *server) projects(c echo.Context) error {
@@ -43,7 +44,11 @@ func (s *server) projects(c echo.Context) error {
 	optProjects.SetSkip(int64((page - 1) * perPage))
 	optProjects.SetLimit(int64(perPage))
 
-	data, err := s.db.GetAll(&rules.Project{}, nil, optProjects)
+	project := rules.Project{}
+	searchStr := c.QueryParam("q")
+	searchQuery := s.db.BuildSearchQueryFromString(searchStr, project)
+
+	data, err := s.db.GetAll(&project, searchQuery, optProjects)
 	if err != nil {
 		return err
 	}

--- a/db/db.go
+++ b/db/db.go
@@ -23,7 +23,7 @@ type mongoCollection struct {
 
 type DB interface {
 	Aggregate(d rules.Queryable, pipeline interface{}) ([]bson.M, error)
-	BuildSearchQueryFromString(q string, d rules.Queryable) bson.M
+	BuildSearchQueryFromString(d rules.Queryable, q string) bson.M
 	DeleteMany(d rules.Queryable, q bson.M) (*mongo.DeleteResult, error)
 	Get(d rules.Queryable, q bson.M, o *options.FindOneOptions) error
 	GetAll(d rules.Queryable, q bson.M, o *options.FindOptions) ([]rules.Queryable, error)
@@ -126,7 +126,7 @@ func (m mongoCollection) GetAll(d rules.Queryable, q bson.M, opts *options.FindO
 	return items, nil
 }
 
-func (m mongoCollection) BuildSearchQueryFromString(q string, d rules.Queryable) bson.M {
+func (m mongoCollection) BuildSearchQueryFromString(d rules.Queryable, q string) bson.M {
 	fields := d.GetSearchableFields()
 	if q == "" || fields == nil {
 		return nil

--- a/db/db.go
+++ b/db/db.go
@@ -23,12 +23,12 @@ type mongoCollection struct {
 
 type DB interface {
 	Aggregate(d rules.Queryable, pipeline interface{}) ([]bson.M, error)
+	BuildSearchQueryFromString(q string, d rules.Queryable) bson.M
 	DeleteMany(d rules.Queryable, q bson.M) (*mongo.DeleteResult, error)
 	Get(d rules.Queryable, q bson.M, o *options.FindOneOptions) error
 	GetAll(d rules.Queryable, q bson.M, o *options.FindOptions) ([]rules.Queryable, error)
 	Insert(d rules.Queryable) (*mongo.InsertOneResult, error)
 	InsertMany(d rules.Queryable, i []interface{}) (*mongo.InsertManyResult, error)
-	BuildSearchQueryFromString(searchStr string, d rules.Queryable) bson.M
 }
 
 func newDBContext() (context.Context, context.CancelFunc) {
@@ -126,18 +126,16 @@ func (m mongoCollection) GetAll(d rules.Queryable, q bson.M, opts *options.FindO
 	return items, nil
 }
 
-func (m mongoCollection) BuildSearchQueryFromString(searchStr string, d rules.Queryable) bson.M {
+func (m mongoCollection) BuildSearchQueryFromString(q string, d rules.Queryable) bson.M {
 	fields := d.GetSearchableFields()
-	if searchStr == "" || fields == nil {
+	if q == "" || fields == nil {
 		return nil
 	}
 
-	searchRegex := bson.M{"$regex": primitive.Regex{Pattern: searchStr, Options: "i"}}
+	searchRegex := bson.M{"$regex": primitive.Regex{Pattern: q, Options: "i"}}
 	queryFields := []bson.M{}
 	for _, field := range fields {
-		q := bson.M{}
-		q[field] = searchRegex
-		queryFields = append(queryFields, q)
+		queryFields = append(queryFields, bson.M{field: searchRegex})
 	}
 
 	return bson.M{"$or": queryFields}

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -66,6 +66,14 @@ var doc = `{
                 ],
                 "summary": "Show projects",
                 "operationId": "get-projects",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "fuzzy search projects",
+                        "name": "q",
+                        "in": "query"
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -51,6 +51,14 @@
                 ],
                 "summary": "Show projects",
                 "operationId": "get-projects",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "fuzzy search projects",
+                        "name": "q",
+                        "in": "query"
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -69,6 +69,11 @@ paths:
       - application/json
       description: get all projects
       operationId: get-projects
+      parameters:
+      - description: fuzzy search projects
+        in: query
+        name: q
+        type: string
       produces:
       - application/json
       responses:

--- a/rules/project.go
+++ b/rules/project.go
@@ -20,3 +20,7 @@ func (p Project) Cast() Queryable {
 func (p Project) GetCollectionName() string {
 	return "projects"
 }
+
+func (p Project) GetSearchableFields() []string {
+	return []string{"name", "weburl", "pathwithnamespace", "description"}
+}

--- a/rules/queryable.go
+++ b/rules/queryable.go
@@ -6,4 +6,5 @@ package rules
 type Queryable interface {
 	Cast() Queryable
 	GetCollectionName() string
+	GetSearchableFields() []string
 }

--- a/rules/rule.go
+++ b/rules/rule.go
@@ -25,6 +25,10 @@ func (r Rule) GetCollectionName() string {
 	return "rules"
 }
 
+func (r Rule) GetSearchableFields() []string {
+	return nil
+}
+
 func NewRule(p *gitlab.Project, r Ruler) Rule {
 	return Rule{
 		Description:       p.Description,

--- a/rules/stats.go
+++ b/rules/stats.go
@@ -21,3 +21,7 @@ func (s Stats) Cast() Queryable {
 func (s Stats) GetCollectionName() string {
 	return "statistics"
 }
+
+func (s Stats) GetSearchableFields() []string {
+	return nil
+}


### PR DESCRIPTION
We can now search projects using the `q` param to go through the following fields (easy to change using the `GetSearchableFields` queryable method):

- name
- weburl
- pathwithnamespace
- description

Closes #3 