### PR TITLE
Add rule for HuskyCI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ swagger:
 	@swag init
 
 test:
-	go run github.com/onsi/ginkgo/ginkgo@v1.16.4 -r .
+	go run github.com/onsi/ginkgo/ginkgo -r .
 
 lint:
 ifndef GOLANG_LINT_COMMAND

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/viper v1.7.1
-	github.com/swaggo/echo-swagger v1.1.0
+	github.com/swaggo/echo-swagger v1.1.4
 	github.com/swaggo/swag v1.7.0
 	github.com/xanzy/go-gitlab v0.43.0
 	go.mongodb.org/mongo-driver v1.7.3

--- a/go.sum
+++ b/go.sum
@@ -106,6 +106,7 @@ github.com/go-playground/universal-translator v0.17.0 h1:icxd5fm+REJzpZx7ZfpaD87
 github.com/go-playground/universal-translator v0.17.0/go.mod h1:UkSxE5sNxxRwHyU+Scu5vgOQjsIJAF8j9muTVoKLVtA=
 github.com/go-stack/stack v1.8.0 h1:5SgMzNM5HxrEjV0ww2lTmX6E2Izsfxas4+YHWRs3Lsk=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
+github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0 h1:p104kn46Q8WdvHunIJ9dAyjPVtrBPhSr3KT2yUst43I=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
 github.com/gobuffalo/attrs v0.0.0-20190224210810-a9411de4debd/go.mod h1:4duuawTqi2wkkpB4ePgWMaai6/Kc6WEz83bhFwpHzj0=
 github.com/gobuffalo/depgen v0.0.0-20190329151759-d478694a28d3/go.mod h1:3STtPUQYuzV0gBVOY3vy6CfMm/ljR4pABfrTeHNLHUY=
@@ -390,8 +391,8 @@ github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
-github.com/swaggo/echo-swagger v1.1.0 h1:P46vSnGTjCo4PCDnztbyyiJ9csTt8/GvwL6UIhr4zEM=
-github.com/swaggo/echo-swagger v1.1.0/go.mod h1:JaipWDPqOBMwM40W6qz0o07lnPOxrhDkpjA2OaqfzL8=
+github.com/swaggo/echo-swagger v1.1.4 h1:uC5s/ynSwl0iJZTOMfSUGwHPRr0jLChMxb1YRMMWjfk=
+github.com/swaggo/echo-swagger v1.1.4/go.mod h1:JaipWDPqOBMwM40W6qz0o07lnPOxrhDkpjA2OaqfzL8=
 github.com/swaggo/files v0.0.0-20190704085106-630677cd5c14 h1:PyYN9JH5jY9j6av01SpfRMb+1DWg/i3MbGOKPxJ2wjM=
 github.com/swaggo/files v0.0.0-20190704085106-630677cd5c14/go.mod h1:gxQT6pBGRuIGunNf/+tSOB5OHvguWi8Tbt82WOkf35E=
 github.com/swaggo/swag v1.7.0 h1:5bCA/MTLQoIqDXXyHfOpMeDvL9j68OY/udlK4pQoo4E=

--- a/rules/my_registry.go
+++ b/rules/my_registry.go
@@ -14,4 +14,5 @@ func init() {
 	MyRegistry.AddRule(NewWithoutGitlabCI())
 	MyRegistry.AddRule(NewWithoutReadme())
 	MyRegistry.AddRule(NewWithoutMakefile())
+	MyRegistry.AddRule(NewWithoutHuskyCI())
 }

--- a/rules/without_huskyci.go
+++ b/rules/without_huskyci.go
@@ -1,0 +1,55 @@
+// Copyright (c) 2021, Gustavo Covas
+// Licensed under the BSD 3-Clause License
+
+package rules
+
+import (
+	"encoding/base64"
+	"strings"
+
+	"github.com/xanzy/go-gitlab"
+)
+
+type WithoutHuskyCI struct {
+	Description string `json:"description"`
+	ID          string `json:"ruleId"`
+	Level       string `json:"level"`
+	Name        string `json:"name"`
+}
+
+func (w *WithoutHuskyCI) Run(c *gitlab.Client, p *gitlab.Project) bool {
+	gf := &gitlab.GetFileOptions{
+		Ref: gitlab.String(p.DefaultBranch),
+	}
+	file, _, err := c.RepositoryFiles.GetFile(
+		p.PathWithNamespace, ".gitlab-ci.yml", gf,
+	)
+	if err != nil {
+		return false
+	}
+
+	contents, err := base64.StdEncoding.DecodeString(file.Content)
+	if err != nil {
+		return false
+	}
+
+	return !strings.Contains(string(contents), "huskyCI")
+}
+
+func (w *WithoutHuskyCI) GetSlug() string {
+	return "without-husky-ci"
+}
+
+func (w *WithoutHuskyCI) GetLevel() string {
+	return LevelInfo
+}
+
+func NewWithoutHuskyCI() Ruler {
+	w := &WithoutHuskyCI{
+		Name:        "Without Husky CI",
+		Description: "Gitlab CI definitions does not contain the string 'huskyCI'",
+	}
+	w.ID = w.GetSlug()
+	w.Level = w.GetLevel()
+	return w
+}

--- a/rules/without_huskyci_test.go
+++ b/rules/without_huskyci_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, Paulo Ricardo Koch
+// Copyright (c) 2021, Gustavo Covas
 // Licensed under the BSD 3-Clause License
 
 package rules_test
@@ -9,7 +9,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("Without Makefile Test", func() {
+var _ = Describe("Without HuskyCI Test", func() {
 	BeforeEach(func() {
 	})
 
@@ -18,20 +18,20 @@ var _ = Describe("Without Makefile Test", func() {
 			// Arrange
 
 			// Act
-			rule := NewWithoutMakefile()
+			rule := NewWithoutHuskyCI()
 
 			// Assert
 			Expect(rule.GetLevel()).To(Equal("info"))
 		})
 
-		It("GetSlug should return without-makefile", func() {
+		It("GetSlug should return without-husky-ci", func() {
 			// Arrange
 
 			// Act
-			rule := NewWithoutMakefile()
+			rule := NewWithoutHuskyCI()
 
 			// Assert
-			Expect(rule.GetSlug()).To(Equal("without-makefile"))
+			Expect(rule.GetSlug()).To(Equal("without-husky-ci"))
 		})
 	})
 })


### PR DESCRIPTION
Add rule to check whether Gitlab CI definitions contains the string 'huskyCI': https://huskyci.opensource.globo.com/

The rule will return `true` if the string is not found. (This would mean that HuskyCI is probably not used in the repository)

I could not write interesting tests for this, since it would require us to mock the `gitlab.Client` struct. Any thoughts for these?

