### PR TITLE
Adding DASThund verify

### DIFF
--- a/rules/my_registry.go
+++ b/rules/my_registry.go
@@ -14,4 +14,5 @@ func init() {
 	MyRegistry.AddRule(NewWithoutGitlabCI())
 	MyRegistry.AddRule(NewWithoutReadme())
 	MyRegistry.AddRule(NewWithoutMakefile())
+	MyRegistry.AddRule(NewWithoutDASThund())
 }

--- a/rules/without_dasthund.go
+++ b/rules/without_dasthund.go
@@ -1,0 +1,52 @@
+package rules
+
+import (
+	"encoding/base64"
+	"strings"
+
+	"github.com/xanzy/go-gitlab"
+)
+
+type WithoutDASThund struct {
+	Description string `json:"description"`
+	ID          string `json:"ruleId"`
+	Level       string `json:"level"`
+	Name        string `json:"name"`
+}
+
+func (w *WithoutDASThund) Run(c *gitlab.Client, p *gitlab.Project) bool {
+	gf := &gitlab.GetFileOptions{
+		Ref: gitlab.String(p.DefaultBranch),
+	}
+	file, _, err := c.RepositoryFiles.GetFile(
+		p.PathWithNamespace, ".gitlab-ci.yml", gf,
+	)
+	if err != nil {
+		return false
+	}
+
+	contents, err := base64.StdEncoding.DecodeString(file.Content)
+	if err != nil {
+		return false
+	}
+
+	return !strings.Contains(string(contents), "dasthund")
+}
+
+func (w *WithoutDASThund) GetSlug() string {
+	return "without-dasthund"
+}
+
+func (w *WithoutDASThund) GetLevel() string {
+	return LevelInfo
+}
+
+func NewWithoutDASThund() Ruler {
+	w := &WithoutDASThund{
+		Name:        "Without DASThund",
+		Description: "Gitlab CI definitions does not contain the string 'dasthund' that initiate a Dynamic Security Testing",
+	}
+	w.ID = w.GetSlug()
+	w.Level = w.GetLevel()
+	return w
+}

--- a/rules/without_dasthund_test.go
+++ b/rules/without_dasthund_test.go
@@ -1,0 +1,26 @@
+package rules_test
+
+import (
+	. "github.com/globocom/gitlab-lint/rules"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Without DASThund Test", func() {
+	BeforeEach(func() {
+	})
+
+	Context("Test rules", func() {
+		It("GetLevel should return info", func() {
+			rule := NewWithoutDASThund()
+
+			Expect(rule.GetLevel()).To(Equal("info"))
+		})
+
+		It("GetSlug should return without-dasthund", func() {
+			rule := NewWithoutDASThund()
+
+			Expect(rule.GetSlug()).To(Equal("without-dasthund"))
+		})
+	})
+})


### PR DESCRIPTION
DASThund is a Dynamic Security Testing provided by secDevOps-Globo team.